### PR TITLE
Fixed styling issue & typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Register for Hacktoberfest: Navigate to the [Hacktoberfest registration page](ht
 
 ## Steps For Contribution
 
-    1. Fork this repo
-    2. Star this repo
-    3. Go to `pages` ➡️ `api` ➡️ `getContributersData.js` 
-    4. Add your details in `getContributersData.js` 
-    5. commit the code
-    6. Make pull request
+1. Fork this repo
+2. Star this repo
+3. Go to <code>pages</code> ➡️ <code>api</code> ➡️ <code>getContributersData.js</code> 
+4. Add your details in <code>getContributersData.js</code> 
+5. commit the code
+6. Make pull request
     
 
 ## For Freshers
 
-1. Complete the registartion over https://hacktoberfest.com/
+1. Complete the registration over https://hacktoberfest.com/
 2. Fork this repository.
 3. Clone on your local machine.
 


### PR DESCRIPTION
I noticed a styling issue in the `README`. The files & directories you wanted to show as `code snippets` were not rendered as expected. I've tried to fix those.

Before:
![image](https://user-images.githubusercontent.com/31766648/197221427-3e304b1c-bc1e-4291-9d14-32e56b648e4a.png)

After:
![image](https://user-images.githubusercontent.com/31766648/197221536-9b61d526-bc6d-4841-99aa-51834bd88cfd.png)

---------------------------------------------------------------------------------------------------

Also fixed a minor typo that I noticed in `README`